### PR TITLE
build: make ethers truly optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
+    },
+    "./ethers": {
+      "types": "./dist/internal/blockchain/adapters/ethers/ethersAdapters.d.ts",
+      "require": "./dist/internal/blockchain/adapters/ethers/ethersAdapters.cjs",
+      "import": "./dist/internal/blockchain/adapters/ethers/ethersAdapters.js"
     }
   },
   "files": [
@@ -29,7 +35,7 @@
     "lint": "gts lint",
     "fix": "gts fix",
     "clean": "gts clean && rm -rf build",
-    "compile": "tsup src/index.ts --format esm,cjs --dts --out-dir dist --tsconfig tsconfig.build.json --external peerDependencies --splitting --treeshake",
+    "compile": "tsup src/index.ts src/internal/blockchain/adapters/ethers/ethersAdapters.ts --format esm,cjs --dts --out-dir dist --tsconfig tsconfig.build.json --external peerDependencies --splitting --treeshake",
     "prepare": "npm run compile",
     "pretest": "tsc --noEmit --project tsconfig.json",
     "posttest": "npm run lint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,6 @@ export {createDripsSdk} from './sdk/createDripsSdk';
 
 export {createPinataIpfsMetadataUploader} from './internal/shared/createPinataIpfsMetadataUploader';
 export {
-  createEthersReadAdapter,
-  createEthersWriteAdapter,
-} from './internal/blockchain/adapters/ethers/ethersAdapters';
-export {
   createViemReadAdapter,
   createViemWriteAdapter,
 } from './internal/blockchain/adapters/viem/viemAdapters';

--- a/src/internal/blockchain/BlockchainAdapter.ts
+++ b/src/internal/blockchain/BlockchainAdapter.ts
@@ -1,4 +1,4 @@
-import {Address, Hash, Hex} from 'viem';
+import type {Address, Hash, Hex} from 'viem';
 
 export type BatchedTxOverrides = {
   nonce?: number;

--- a/src/internal/blockchain/resolveBlockchainAdapter.ts
+++ b/src/internal/blockchain/resolveBlockchainAdapter.ts
@@ -1,5 +1,4 @@
 import {WalletClient} from 'viem';
-import type {Provider, Signer} from 'ethers';
 import {SupportedBlockchainClient} from '../../sdk/createDripsSdk';
 import {DripsError} from '../shared/DripsError';
 import {
@@ -54,7 +53,8 @@ export function resolveBlockchainAdapter(
     !('transport' in client) &&
     hasRequiredMethods(client, ['signMessage', 'getAddress'])
   ) {
-    return createEthersWriteAdapter(client as Signer);
+    // Cast to any to avoid leaking ethers types from public API.
+    return createEthersWriteAdapter(client as any);
   }
 
   // Ethers read-only client
@@ -63,7 +63,7 @@ export function resolveBlockchainAdapter(
     hasRequiredMethods(client, ['call']) &&
     !('signMessage' in client)
   ) {
-    return createEthersReadAdapter(client as Provider);
+    return createEthersReadAdapter(client as any);
   }
 
   throw new DripsError('Unsupported client type for blockchain adapter', {

--- a/src/sdk/createDripsSdk.ts
+++ b/src/sdk/createDripsSdk.ts
@@ -2,8 +2,7 @@ import {
   IpfsMetadataUploaderFn,
   Metadata,
 } from '../internal/shared/createPinataIpfsMetadataUploader';
-import {PublicClient, WalletClient} from 'viem';
-import type {Provider, Signer} from 'ethers';
+import type {PublicClient, WalletClient} from 'viem';
 import {
   ReadBlockchainAdapter,
   WriteBlockchainAdapter,
@@ -39,11 +38,23 @@ type DripsSdkOptions = {
   };
 };
 
+interface EthersLikeProvider {
+  call: (...args: any[]) => Promise<any>;
+  getNetwork: () => Promise<{chainId: bigint | number}>;
+}
+
+interface EthersLikeSigner {
+  getAddress: () => Promise<string>;
+  signMessage: (message: string | Uint8Array) => Promise<any>;
+  sendTransaction: (...args: any[]) => Promise<any>;
+  provider?: unknown;
+}
+
 export type SupportedBlockchainClient =
   | PublicClient
   | WalletClient
-  | Provider
-  | Signer
+  | EthersLikeProvider
+  | EthersLikeSigner
   | (ReadBlockchainAdapter & {type: 'custom'})
   | (WriteBlockchainAdapter & {type: 'custom'});
 

--- a/tests/unit/sdk/createLinkedIdentitiesModule.test.ts
+++ b/tests/unit/sdk/createLinkedIdentitiesModule.test.ts
@@ -122,10 +122,7 @@ describe('createLinkedIdentitiesModule', () => {
       await linkedIdentitiesModule.claimOrcid(params);
 
       // Assert
-      expect(requireWriteAccess).toHaveBeenCalledWith(
-        adapter,
-        'claimOrcid',
-      );
+      expect(requireWriteAccess).toHaveBeenCalledWith(adapter, 'claimOrcid');
     });
 
     it('should work with ReadBlockchainAdapter when requireWriteAccess is mocked to pass', async () => {
@@ -178,4 +175,3 @@ describe('createLinkedIdentitiesModule', () => {
     });
   });
 });
-


### PR DESCRIPTION
Now, `ethers` related code is imported like:
`import {createEthersReadAdapter} from '@drips-network/sdk/ethers';`